### PR TITLE
Remove early return that kills other middlewares

### DIFF
--- a/sanic_prometheus/__init__.py
+++ b/sanic_prometheus/__init__.py
@@ -77,7 +77,6 @@ def monitor(app, endpoint_type='url:1',
     async def before_response(request, response):
         if request.path != '/metrics':
             metrics.after_request_handler(m, request, response, get_endpoint)
-        return response
 
     # can't access the loop directly before Sanic starts
     get_loop_fn = lambda: app.loop


### PR DESCRIPTION
This extension breaks every other middleware by using an unneeded early response. This fixes it.