### PR TITLE
add http_status as a label

### DIFF
--- a/sanic_prometheus/metrics.py
+++ b/sanic_prometheus/metrics.py
@@ -25,7 +25,7 @@ def init(
     metrics['RQS_LATENCY'] = Histogram(
         'sanic_request_latency_sec',
         'Sanic Request Latency Histogram',
-        ['method', 'endpoint'],
+        ['method', 'endpoint', 'http_status'],
         **hist_kwargs
     )
 
@@ -61,6 +61,7 @@ def before_request_handler(request):
 def after_request_handler(request, response, get_endpoint_fn):
     lat = time.time() - request['__START_TIME__']
     endpoint = get_endpoint_fn(request)
-    METRICS['RQS_LATENCY'].labels(request.method, endpoint).observe(lat)
+    METRICS['RQS_LATENCY'].labels(request.method, endpoint,
+                                  response.status).observe(lat)
     METRICS['RQS_COUNT'].labels(request.method, endpoint,
                                 response.status).inc()


### PR DESCRIPTION
Added label for being able to distinguish between success and failure request. Failing request may respond very early or very late and can skew overall latency metric