### PR TITLE
Add websocket support for metrics

### DIFF
--- a/sanic_prometheus/metrics.py
+++ b/sanic_prometheus/metrics.py
@@ -62,5 +62,8 @@ def after_request_handler(request, response, get_endpoint_fn):
     lat = time.time() - request['__START_TIME__']
     endpoint = get_endpoint_fn(request)
     METRICS['RQS_LATENCY'].labels(request.method, endpoint).observe(lat)
+    # Note, that some handlers can ignore response logic,
+    # for example, websocket handler
+    response_status = response.status if response else 200
     METRICS['RQS_COUNT'].labels(request.method, endpoint,
-                                response.status).inc()
+                                response_status).inc()


### PR DESCRIPTION
Currently, websocket handlers, like 

```python
@task_api.websocket('/task/feed')
async def feed(request, ws):
    request.app.websocket_storage.add(ws)
    try:
        while True:
            await ws.send(ujson.dumps({"type": "hearthbeat", "data": {"worker_id": request.app.worker.id}}))
            await asyncio.sleep(60)
    finally:
        request.app.websocket_storage.remove(ws)
```

cause exceptions in program

```
Traceback (most recent call last):
  File "/home/siredvin/.pyenv/http-cron/lib/python3.6/site-packages/sanic/app.py", line 580, in handle_request
    response)
  File "/home/siredvin/.pyenv/http-cron/lib/python3.6/site-packages/sanic/app.py", line 727, in _run_response_middleware
    _response = await _response
  File "/home/siredvin/.pyenv/http-cron/lib/python3.6/site-packages/sanic_prometheus/__init__.py", line 115, in before_response
    metrics.after_request_handler(request, response, get_endpoint)
  File "/home/siredvin/.pyenv/http-cron/lib/python3.6/site-packages/sanic_prometheus/metrics.py", line 66, in after_request_handler
    response.status).inc()
AttributeError: 'NoneType' object has no attribute 'status'
```

According to sanic documentation, websocket handler shouldn't return any response, so I suggest add some response check to middleware.