### PR TITLE
Specify prometheus-client version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     platforms='any',
     install_requires=[
         'sanic>=0.5.0',
-        'prometheus-client>=0.0.19',
+        'prometheus-client~=0.4.2',
         'psutil>=5.2.0'
     ],
     classifiers=[


### PR DESCRIPTION
See #17. Latest version of prometheus-client breaks this package, so specify a specific version requirement.