### PR TITLE
 Added ability to customize /metrics path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 0.1.8 (on Apr 9, 2019)
+-------------------------------
+* Add metrics_path kwarg to monitor() in order to customize /metrics
+
 Version 0.1.7 (on Jan 25, 2019)
 -------------------------------
 * Make it work with newer versions of prometheus-client (>= 0.5.0)

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Versions compatibility
 * ☑︎ use **0.1.3** for Sanic >= 0.5.0
 * ☑︎ use >= **0.1.4** if you need multiprocessing support
 * ☑︎ use **0.1.6** if you have to use `promtheus-client` <= 0.4.2
-* ☑︎ use **0.1.7** with `prometheus-client` >= 0.5.0
+* ☑︎ use **0.1.8** with `prometheus-client` >= 0.5.0
 
 Exposed metrics
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,8 @@ Actually, there're two ways to run monitoring:
    It just adds a new ``route`` to your Sanic app, exposing ``/metrics`` endpoint
    on the same host and port your Sanic server runs. It might be useful if you run your
    app in a container and you do not want to expose different ports for metrics and everything else.
+   You can customize the ``/metrics`` endpoint by passing the ``metrics_path`` keyword argument:
+   ``monitor(app, metrics_path='/my_metrics_path').expose_endpoint()``.
 2. ``monitor(app).start_server(addr=..., port=...)``.
    Runs a HTTP server on given address and port and exposes ``/metrics`` endpoint on it.
    This might be useful if you want to restrict access to your ``/metrics`` endpoint using some

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='sanic-prometheus',
-    version='0.1.7',
+    version='0.1.8',
     description='Exposes various prometheus monitoring metrics of Sanic-based apps.',
     url='http://github.com/dkruchinin/sanic-prometheus',
     author='Dan Kruchinin',


### PR DESCRIPTION
My company uses a different path for exposing metrics, would be great to make this configurable.