### PR TITLE
Ignore request whose method is OPTIONS

### DIFF
--- a/sanic_prometheus/__init__.py
+++ b/sanic_prometheus/__init__.py
@@ -109,12 +109,12 @@ def monitor(app, endpoint_type='url:1',
 
     @app.middleware('request')
     async def before_request(request):
-        if request.path != metrics_path:
+        if request.path != metrics_path and request.method != "OPTIONS":
             metrics.before_request_handler(request)
 
     @app.middleware('response')
     async def before_response(request, response):
-        if request.path != metrics_path:
+        if request.path != metrics_path and request.method != "OPTIONS":
             metrics.after_request_handler(request, response, get_endpoint)
 
     if multiprocess_on:


### PR DESCRIPTION
I always get a KeyError on requests whose method is OPTIONS because `before_request(request)` is not executed for those requests and `request['__START_TIME__']` is not set, I don't think it makes any sense to monitor OPTIONS requests anyways.