### PR TITLE
Sanic ctx upgrade: Update the request namespace to newer sanic ctx

### DIFF
--- a/sanic_prometheus/metrics.py
+++ b/sanic_prometheus/metrics.py
@@ -49,11 +49,11 @@ async def periodic_memcollect_task(app, period_sec, loop):
 
 
 def before_request_handler(request):
-    request['__START_TIME__'] = time.time()
+    request.ctx.__START_TIME__ = time.time()
 
 
 def after_request_handler(request, response, get_endpoint_fn):
-    lat = time.time() - request['__START_TIME__']
+    lat = time.time() - request.ctx.__START_TIME__
     endpoint = get_endpoint_fn(request)
 
     # Note, that some handlers can ignore response logic,


### PR DESCRIPTION
Changed the sanic request ctx for __START_TIME__ for the middleware is going to be deprecated, added the newer ctx way for adding custom objects.